### PR TITLE
Adding list-context.media-list block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `list-context.media-list` block that provides a list context of images and videos
+- `list-context.media-list` block that provides a list context of images and videos.
   
 ### Changed
-- Improved other apps' CSS Handles imports
+- Improved imports of CSS Handles from `vtex.store-video` and `vtex.store-image`.
 
 ## [0.1.0] - 2021-01-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `list-context.media-list` block that provides a list context of images and videos
+  
+### Changed
+- Improved other apps' CSS Handles imports
 
 ## [0.1.0] - 2021-01-22
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,12 +26,12 @@ Now, you are able to use all blocks exported by the `store-media` app. Check out
 
 | Block name                | Description                                                                                                                                                                                                                                               |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `media`                   | This block is capable to display a single image or video.                                                                                                                                                                                                 |
-| `list-context.media-list` | This block allows you to display a list of images and videos in your store with a higher degree of composability, since you can use it along with other `list-context` or `slider-layout` blocks to create a more flexible and customizable image slider. |
+| `media`                   | This block is capable of displaying a single image or video.                                                                                                                                                                                                 |
+| `list-context.media-list` | This block allows you to display a list of images and videos in your store with a higher degree of composability. You can use it along with other `list-context` or `slider-layout` blocks to create different sliders and layouts. |
 
 ### `media` block
 
-The `media` block inherits all props from `image` and `video` blocks. It's highly recommended for you to check out the docs for [Image](https://github.com/vtex-apps/store-image) and [Video](https://github.com/vtex-apps/store-video) blocks before using this block.
+The `media` block inherits all props from `image` and `video` blocks. It's highly recommended you check out the docs for [Image](https://github.com/vtex-apps/store-image) and [Video](https://github.com/vtex-apps/store-video) blocks before using this block.
 
 You can use props from both blocks, but `media` will only consider the props from the block (`image` or `video`) that matches the current `mediaType`, or, in the case of `mediaType` being `imageOrVideo`, that matches the type of the `src`.
 
@@ -54,7 +54,7 @@ Use the **admin's Site Editor** to manage some props declared in the `media` blo
 
 ### `list-context.media-list` block
 
-The `list-context.media-list` block acts just like the `list-context.image-list` and inherits a lot from `image` and `video` blocks, with a few key differences. It's highly recommended for you to check out the docs for [Image](https://github.com/vtex-apps/store-image) and [Video](https://github.com/vtex-apps/store-video) blocks before using this block.
+The `list-context.media-list` block acts just like the `list-context.image-list` block and inherits a lot from `image` and `video` blocks, with a few key differences. It's highly recommended you check out the docs for [Image](https://github.com/vtex-apps/store-image) and [Video](https://github.com/vtex-apps/store-video) blocks before using this block.
 
 `list-context.media-list` accepts both images and videos, so you can mix them inside a single carousel, for example. Images can receive `image` blocks' props and videos can receive `video` blocks' props. If you pass props that don't match the media type, they will be ignored.
 
@@ -65,7 +65,7 @@ The `list-context.media-list` block acts just like the `list-context.image-list`
 
 - `MediaListElement` object
 
-A `MediaListElement` object is almost equal to the props accepted by the `media` component, that is, you can specify the `mediaType` of the asset you're providing and pass the props for `image` and `video` blocks. Read the docs for the `media` block to better understand how that works.
+A `MediaListElement` object has a very similar shape to the props accepted by the `media` component, that is, you can specify the `mediaType` of the asset you want to display and pass the props for `image` and `video` blocks. Read the docs for the `media` block to better understand how that works.
 
 Differently from the `media` component, it does **not** use the `src` prop to receive the assets. For images, it uses the `image` and `mobileImage` props, and, for video, it uses the `video` and `mobileVideo` props.
 
@@ -117,7 +117,7 @@ Differently from the `media` component, it does **not** use the `src` prop to re
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-Just like they do with props, the all blocks from this app inherits all of `image` and `video` blocks' CSS Handles. You can find them in their respective docs.
+Just like they do with props, all blocks from this app inherits all of `image` and `video` blocks' CSS Handles. You can find them in their respective docs.
 
 Keep in mind that, for instance, applying CSS customizations to CSS Handles that came from `image` won't have any effect if the `mediaType` is set to `video` or if the `mediaType` is set to `imageOrVideo` and the `src` was identified as a video.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 
 The Media app allows you to display image and video assets using a single block.
 
+![media-list-example](https://user-images.githubusercontent.com/8127610/107076678-848fbf80-67ca-11eb-9ba3-8a7d285c4b2c.gif)
 ## Configuration
 
 1. Add the `store-media` app to your theme's dependencies in the `manifest.json` file:

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,18 +22,14 @@ The Media app allows you to display image and video assets using a single block.
  }
 ```
 
-2. In any desired theme template, add the `media` block with the desirable props. For example:
+Now, you are able to use all blocks exported by the `store-media` app. Check out the full list below:
 
-```json
-"media#mobile-phone": {
-  "props": {
-    "src": "https://storecomponents.vteximg.com.br/arquivos/mobile-phone.png",
-    "blockClass": "storePrint"
-  }
-}
-```
+| Block name                | Description                                                                                                                                                                                                                                               |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `media`                   | This block is capable to display a single image or video.                                                                                                                                                                                                 |
+| `list-context.media-list` | This block allows you to display a list of images and videos in your store with a higher degree of composability, since you can use it along with other `list-context` or `slider-layout` blocks to create a more flexible and customizable image slider. |
 
-### `media` props
+### `media` block
 
 The `media` block inherits all props from `image` and `video` blocks. It's highly recommended for you to check out the docs for [Image](https://github.com/vtex-apps/store-image) and [Video](https://github.com/vtex-apps/store-video) blocks before using this block.
 
@@ -45,11 +41,83 @@ You can use props from both blocks, but `media` will only consider the props fro
 
 Use the **admin's Site Editor** to manage some props declared in the `media` block. Using the Site Editor to provide the image or video `src` will force you to choose between `image` and `video`.
 
+**Usage Example**:
+
+```json
+"media#mobile-phone": {
+  "props": {
+    "src": "https://storecomponents.vteximg.com.br/arquivos/mobile-phone.png",
+    "blockClass": "storePrint"
+  }
+}
+```
+
+### `list-context.media-list` block
+
+The `list-context.media-list` block acts just like the `list-context.image-list` and inherits a lot from `image` and `video` blocks, with a few key differences. It's highly recommended for you to check out the docs for [Image](https://github.com/vtex-apps/store-image) and [Video](https://github.com/vtex-apps/store-video) blocks before using this block.
+
+`list-context.media-list` accepts both images and videos, so you can mix them inside a single carousel, for example. Images can receive `image` blocks' props and videos can receive `video` blocks' props. If you pass props that don't match the media type, they will be ignored.
+
+| Prop name   | Type | Description                                                                                                                                                                                                                                                                                                                         | Default value  |
+| ----------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `height` | `string  | number` | This value is used for the `max-height` CSS property and **is applied to images only**. | `420` |
+| `mediaList` | [MediaListElement] | List of `MediaListElement` that represents the media to be added to the list context. | `[]` |
+
+- `MediaListElement` object
+
+A `MediaListElement` object is almost equal to the props accepted by the `media` component, that is, you can specify the `mediaType` of the asset you're providing and pass the props for `image` and `video` blocks. Read the docs for the `media` block to better understand how that works.
+
+Differently from the `media` component, it does **not** use the `src` prop to receive the assets. For images, it uses the `image` and `mobileImage` props, and, for video, it uses the `video` and `mobileVideo` props.
+
+| Prop name   | Type | Description                                                                                                                                                                                                                                                                                                                         | Default value  |
+| ----------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `image` | `string` | URL to the image to be displayed. | undefined |
+| `mobileImage` | `string` | URL to the image to be displayed when the user is using a mobile device. If it's undefined, `image` will be used instead. | undefined |
+| `video` | `string` | URL to the video to be displayed. | undefined |
+| `mobileVideo` | `string` | URL to the video to be displayed when the user is using a mobile device. If it's undefined, `video` will be used instead. | undefined |
+
+
+**Usage Example**:
+
+```json
+"list-context.media-list#demo": {
+  "children": ["slider-layout#demo-media"],
+  "props": {
+    "height": 720,
+    "mediaList": [
+      {
+        "image": "https://storecomponents.vteximg.com.br/arquivos/banner-principal.png",
+        "mobileImage": "https://storecomponents.vteximg.com.br/arquivos/banner-principal-mobile.jpg"
+      },
+      {
+        "video": "https://www.youtube.com/embed/JgkrlaF52WQ"
+      },
+      {
+        "image": "https://storecomponents.vteximg.com.br/arquivos/banner.jpg",
+        "mobileImage": "https://storecomponents.vteximg.com.br/arquivos/banner-principal-mobile.jpg"
+      }
+    ]
+  }
+},
+"slider-layout#demo-media": {
+  "props": {
+    "itemsPerPage": {
+      "desktop": 1,
+      "tablet": 1,
+      "phone": 1
+    },
+    "infinite": true,
+    "showNavigationArrows": "desktopOnly",
+    "blockClass": "carousel"
+  }
+}
+```
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-Just like it does with props, the `media` block inherits all of `image` and `video` blocks' CSS Handles. You can find them in their respective docs.
+Just like they do with props, the all blocks from this app inherits all of `image` and `video` blocks' CSS Handles. You can find them in their respective docs.
 
 Keep in mind that, for instance, applying CSS customizations to CSS Handles that came from `image` won't have any effect if the `mediaType` is set to `video` or if the `mediaType` is set to `imageOrVideo` and the `src` was identified as a video.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,11 +101,7 @@ Differently from the `media` component, it does **not** use the `src` prop to re
 },
 "slider-layout#demo-media": {
   "props": {
-    "itemsPerPage": {
-      "desktop": 1,
-      "tablet": 1,
-      "phone": 1
-    },
+    "itemsPerPage": 1,
     "infinite": true,
     "showNavigationArrows": "desktopOnly",
     "blockClass": "carousel"

--- a/manifest.json
+++ b/manifest.json
@@ -13,11 +13,11 @@
   "dependencies": {
     "vtex.store-image": "0.x",
     "vtex.store-video": "1.x",
-    "vtex.css-handles": "1.x"
+    "vtex.css-handles": "1.x",
+    "vtex.device-detector": "0.x",
+    "vtex.list-context": "0.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,7 +1,10 @@
 {
   "admin/editor.media.title": "Media",
   "admin/editor.media.description": "Media block that supports images and videos",
-  "admin/editor.media.mediaType.title": "Media type",
-  "admin/editor.media.mediaType.image": "Image",
-  "admin/editor.media.mediaType.video": "Video"
+  "admin/editor.mediaType.title": "Media type",
+  "admin/editor.mediaType.image": "Image",
+  "admin/editor.mediaType.video": "Video",
+  "admin/editor.mediaList.title": "Media List",
+  "admin/editor.mediaList.description": "Media List block that supports a list of images and videos",
+  "admin/editor.mediaList.mobileVideo.title": "URL for mobile"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,7 +1,10 @@
 {
   "admin/editor.media.title": "Media",
   "admin/editor.media.description": "Media block that supports images and videos",
-  "admin/editor.media.mediaType.title": "Media type",
-  "admin/editor.media.mediaType.image": "Image",
-  "admin/editor.media.mediaType.video": "Video"
+  "admin/editor.mediaType.title": "Media type",
+  "admin/editor.mediaType.image": "Image",
+  "admin/editor.mediaType.video": "Video",
+  "admin/editor.mediaList.title": "Media List",
+  "admin/editor.mediaList.description": "Media List block that supports a list of images and videos",
+  "admin/editor.mediaList.mobileVideo.title": "URL for mobile"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,7 +1,10 @@
 {
   "admin/editor.media.title": "Medio",
   "admin/editor.media.description": "Bloque de medio que admite imágenes y videos",
-  "admin/editor.media.mediaType.title": "Tipo de medio",
-  "admin/editor.media.mediaType.image": "Imagen",
-  "admin/editor.media.mediaType.video": "Vídeo"
+  "admin/editor.mediaType.title": "Tipo de medio",
+  "admin/editor.mediaType.image": "Imagen",
+  "admin/editor.mediaType.video": "Vídeo",
+  "admin/editor.mediaList.title": "Lista de Medios",
+  "admin/editor.mediaList.description": "Bloque de Lista de Medios que admite una lista de imágenes y videos",
+  "admin/editor.mediaList.mobileVideo.title": "URL para móvil"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,7 +1,10 @@
 {
   "admin/editor.media.title": "Mídia",
   "admin/editor.media.description": "Bloco de mídia que suporta imagens e vídeos",
-  "admin/editor.media.mediaType.title": "Tipo de mídia",
-  "admin/editor.media.mediaType.image": "Imagem",
-  "admin/editor.media.mediaType.video": "Vídeo"
+  "admin/editor.mediaType.title": "Tipo de mídia",
+  "admin/editor.mediaType.image": "Imagem",
+  "admin/editor.mediaType.video": "Vídeo",
+  "admin/editor.mediaList.title": "Lista de Mídias",
+  "admin/editor.mediaList.description": "Bloco de Lista de Mídias que suporta uma lista de imagens e vídeos",
+  "admin/editor.mediaList.mobileVideo.title": "URL para mobile"
 }

--- a/react/Media.tsx
+++ b/react/Media.tsx
@@ -4,29 +4,10 @@ import { Video } from 'vtex.store-video'
 import { useCssHandles, useCustomClasses } from 'vtex.css-handles'
 import type { CssHandlesTypes } from 'vtex.css-handles'
 
-import type {
-  BlockModeProps,
-  ImageModeProps,
-  MediaProps,
-  VideoModeProps,
-} from './MediaTypes'
+import type { VideoSchema, ImageModeProps, VideoModeProps } from './MediaTypes'
 
-const IMAGE_CSS_HANDLES = ['imageElement', 'imageElementLink'] as const
-const VIDEO_CSS_HANDLES = [
-  'videoContainer',
-  'videoElement',
-  'fallbackContainer',
-  'fallbackImage',
-  'controlsContainer',
-  'playButton',
-  'trackContainer',
-  'trackTimer',
-  'trackBar',
-  'fullscreenButton',
-  'volumeContainer',
-  'volumeSlider',
-  'volumeButton',
-] as const
+const IMAGE_CSS_HANDLES = Image.cssHandles
+const VIDEO_CSS_HANDLES = Video.cssHandles
 
 /*
  * The no-useless-escape rule is disabled on these expressions so they work correctly on the popular
@@ -61,7 +42,7 @@ function isVideoSrc(src?: string) {
 type GetMediaValuesParams = {
   rawSrc?: ImageModeProps['src'] | VideoModeProps['src']
   mediaType: 'image' | 'video' | 'imageOrVideo'
-  videoUrl?: BlockModeProps['videoUrl']
+  videoUrl?: VideoSchema['videoUrl']
 }
 
 function getMediaValues({ rawSrc, mediaType, videoUrl }: GetMediaValuesParams) {
@@ -84,6 +65,8 @@ function getModifiableHandles(handles: CssHandlesTypes.CssHandles<string[]>) {
 
   return modifiableHandles
 }
+
+export type MediaProps = ImageModeProps | VideoModeProps
 
 function Media(props: MediaProps) {
   const { src: rawSrc, mediaType = 'imageOrVideo', classes } = props
@@ -116,7 +99,7 @@ function Media(props: MediaProps) {
    * This prop is used by the schema to receive the source of the video.
    * Since image is using a the src prop, they don't conflict.
    */
-  const { videoUrl } = props as BlockModeProps
+  const { videoUrl } = props as VideoSchema
 
   const { isVideo, src } = getMediaValues({
     rawSrc,

--- a/react/MediaList.tsx
+++ b/react/MediaList.tsx
@@ -5,14 +5,14 @@ import { ListContextProvider, useListContext } from 'vtex.list-context'
 import type { ImageTypes } from 'vtex.store-image'
 
 import { getMediaAsJSXList } from './modules/mediaAsList'
-import type { MediaArray } from './MediaTypes'
+import type { MediaProps } from './MediaTypes'
 
 export interface MediaListProps {
   /**
    * List of Media props that will be turned into a list of Media components
    * @default []
    */
-  mediaList?: MediaArray
+  mediaList?: MediaProps[]
 }
 
 export interface MediaListPropsWithHeight extends MediaListProps {

--- a/react/MediaList.tsx
+++ b/react/MediaList.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import type { PropsWithChildren } from 'react'
+import { useDevice } from 'vtex.device-detector'
+import { ListContextProvider, useListContext } from 'vtex.list-context'
+import type { ImageTypes } from 'vtex.store-image'
+
+import { getMediaAsJSXList } from './modules/mediaAsList'
+import type { MediaArray } from './MediaTypes'
+
+export interface MediaListProps {
+  /**
+   * List of Media props that will be turned into a list of Media components
+   * @default []
+   */
+  mediaList?: MediaArray
+}
+
+export interface MediaListPropsWithHeight extends MediaListProps {
+  /**
+   * maxHeight to be applied to Media in case it's an image and is being used as a block
+   * @default 420
+   */
+  height?: ImageTypes.ImageListProps['height']
+}
+
+/**
+ * MediaList must receive a mediaList containing props identical
+ * to the ones accepted by the Media component, meaning that it
+ * receives 'src' when being used as a component.
+ *
+ * When used as a block, this component acts similar to the list-context.image-list block
+ * present on the vtex.store-image app. It acceps 'image' and 'mobileImage'
+ * to indicate the source of the image and, for video, it receives 'video' and 'mobileVideo'.
+ */
+function MediaList(props: PropsWithChildren<MediaListProps>) {
+  const { mediaList = [], children } = props
+
+  // This is here to mantain compatibility with list-context.image-list
+  const { height } = props as MediaListPropsWithHeight
+
+  const list = useListContext()?.list ?? []
+  const { isMobile } = useDevice()
+
+  const imageListContent = getMediaAsJSXList(mediaList, isMobile, height)
+
+  const newListContextValue = list.concat(imageListContent)
+
+  return (
+    <ListContextProvider list={newListContextValue}>
+      {children}
+    </ListContextProvider>
+  )
+}
+
+MediaList.schema = {
+  title: 'admin/editor.mediaList.title',
+}
+
+export default MediaList

--- a/react/MediaTypes.ts
+++ b/react/MediaTypes.ts
@@ -47,5 +47,3 @@ export type MediaListSchemaElement =
   | VideoListSchemaElement
 
 export type MediaListWithSchema = MediaListSchemaElement[] | MediaProps[]
-
-export type MediaArray = MediaProps[]

--- a/react/MediaTypes.ts
+++ b/react/MediaTypes.ts
@@ -1,23 +1,51 @@
-import { Image } from 'vtex.store-image'
-import type { ComponentProps } from 'react'
 import type { VideoTypes } from 'vtex.store-video'
+import type { ImageTypes } from 'vtex.store-image'
 
-export type ImageProps = ComponentProps<typeof Image>
+import type { MediaProps } from './Media'
+import type { MediaListProps, MediaListPropsWithHeight } from './MediaList'
+
+export { MediaProps, MediaListProps, MediaListPropsWithHeight }
 
 export interface VideoModeProps extends Omit<VideoTypes.VideoPlayer, 'src'> {
+  /**
+   * The type of the media to be displayed
+   * @default 'imageOrVideo'
+   */
   mediaType?: 'video' | 'imageOrVideo'
   src?: VideoTypes.VideoPlayer['src']
 }
 
-export interface ImageModeProps extends ImageProps {
+type ImageModeMediaType = {
+  /**
+   * The type of the media to be displayed
+   * @default 'imageOrVideo'
+   */
   mediaType?: 'image' | 'imageOrVideo'
 }
+
+export type ImageModeProps = ImageModeMediaType & ImageTypes.ImageProps
 
 // Media type will always be defined (image or video), but assuring that here
 // makes the prop autocomplete on this component way less powerful
 // on the test site-editor tests
-export interface BlockModeProps {
+export interface VideoSchema extends Omit<VideoModeProps, 'src'> {
   videoUrl?: VideoTypes.VideoPlayer['src']
 }
 
-export type MediaProps = ImageModeProps | VideoModeProps
+export type MediaSchema = ImageTypes.ImageProps | VideoSchema
+
+export type ImageListSchemaElement = Partial<ImageTypes.ImagesSchema[0]> &
+  ImageModeMediaType
+
+export type VideoListSchemaElement = Omit<VideoModeProps, 'src'> & {
+  video?: VideoModeProps['src']
+  mobileVideo?: VideoModeProps['src']
+}
+
+export type MediaListSchemaElement =
+  | ImageListSchemaElement
+  | VideoListSchemaElement
+
+export type MediaListWithSchema = MediaListSchemaElement[] | MediaProps[]
+
+export type MediaArray = MediaProps[]

--- a/react/__mocks__/vtex.device-detector.tsx
+++ b/react/__mocks__/vtex.device-detector.tsx
@@ -1,0 +1,3 @@
+export function useDevice() {
+  return { isMobile: false }
+}

--- a/react/__mocks__/vtex.list-context.tsx
+++ b/react/__mocks__/vtex.list-context.tsx
@@ -1,0 +1,9 @@
+function ListContextProvider({ list }: { list: JSX.Element[] }) {
+  return list
+}
+
+function useListContext() {
+  return []
+}
+
+export { ListContextProvider, useListContext }

--- a/react/__mocks__/vtex.store-image.tsx
+++ b/react/__mocks__/vtex.store-image.tsx
@@ -1,7 +1,18 @@
 import React from 'react'
 
-import { ImageProps } from '../MediaTypes'
+import { ImageModeProps } from '../MediaTypes'
 
-export function Image({ src, alt }: ImageProps) {
-  return <img src={src} alt={alt} />
+function Image(props: ImageModeProps) {
+  const { src, alt, maxHeight, width } = props
+
+  const style = {
+    maxHeight,
+    width,
+  }
+
+  return <img src={src} alt={alt} style={style} />
 }
+
+Image.cssHandles = [] as string[]
+
+export { Image }

--- a/react/__mocks__/vtex.store-video.tsx
+++ b/react/__mocks__/vtex.store-video.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { VideoTypes } from 'vtex.store-video'
 
-import { BlockModeProps } from '../MediaTypes'
+import { VideoSchema } from '../MediaTypes'
 
 const VIMEO_PATTERN = /vimeo/
 const YOUTUBE_PATTERN = /youtube|youtu.be/
 
-export function Video({ src = '' }: VideoTypes.VideoPlayer & BlockModeProps) {
+function Video({ src = '' }: VideoTypes.VideoPlayer & VideoSchema) {
   if (VIMEO_PATTERN.test(src)) {
     return <div data-testid="vimeo-player" />
   }
@@ -21,3 +21,7 @@ export function Video({ src = '' }: VideoTypes.VideoPlayer & BlockModeProps) {
     </div>
   )
 }
+
+Video.cssHandles = [] as string[]
+
+export { Video }

--- a/react/__tests__/Media.test.tsx
+++ b/react/__tests__/Media.test.tsx
@@ -3,10 +3,10 @@ import type { ComponentType } from 'react'
 import { render } from '@vtex/test-tools/react'
 
 import Media from '../Media'
-import type { BlockModeProps, MediaProps } from '../MediaTypes'
+import type { MediaSchema, MediaProps } from '../MediaTypes'
 
 describe('Using media block via site-editor', () => {
-  const MediaSiteEditor = Media as ComponentType<MediaProps & BlockModeProps>
+  const MediaSiteEditor = Media as ComponentType<MediaProps & MediaSchema>
 
   it('should render a youtube player correctly', () => {
     const { queryByTestId } = render(
@@ -36,7 +36,7 @@ describe('Using media block via site-editor', () => {
 
   it('should render a HTML5 player correctly', () => {
     const { queryByTestId } = render(
-      <MediaSiteEditor mediaType="video" videoUrl="vtex.mp4" />
+      <MediaSiteEditor mediaType="video" videoUrl="http://vtex.com/vtex.mp4" />
     )
 
     expect(queryByTestId('html5-player')).toBeInTheDocument()
@@ -45,8 +45,8 @@ describe('Using media block via site-editor', () => {
   })
 
   it('should render a HTML5 player using videoUrl even if src is set', () => {
-    const videoUrl = 'vtex-video-url.mp4'
-    const src = 'vtex-src.mp4'
+    const videoUrl = 'http://vtex.com/vtex-video-url.mp4'
+    const src = 'http://vtex.com/vtex-src.mp4'
 
     const { queryByTestId } = render(
       <MediaSiteEditor mediaType="video" videoUrl={videoUrl} src={src} />
@@ -85,9 +85,9 @@ describe('Using media block via site-editor', () => {
     expect(queryByAltText(altText)).toHaveAttribute('src', 'vtex.png')
   })
 
-  it('should render an image even if imageUrl is malformed', () => {
+  it('should render an image even if src is malformed', () => {
     const altText = 'vtex-image'
-    const src = 'vtex.png'
+    const src = 'vtex'
 
     const { queryByAltText } = render(
       <MediaSiteEditor mediaType="image" src={src} alt={altText} />
@@ -123,7 +123,9 @@ describe('Using media with fixed mediaType', () => {
   })
 
   it('should render a HTML5 player correctly', () => {
-    const { queryByTestId } = render(<Media mediaType="video" src="vtex.mp4" />)
+    const { queryByTestId } = render(
+      <Media mediaType="video" src="http://vtex.com/vtex.mp4" />
+    )
 
     expect(queryByTestId('html5-player')).toBeInTheDocument()
     expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
@@ -141,7 +143,7 @@ describe('Using media with fixed mediaType', () => {
     expect(queryByTestId('youtube-player')).not.toBeInTheDocument()
   })
 
-  it('should render a nimage correctly', () => {
+  it('should render an image correctly', () => {
     const altText = 'vtex-image'
     const src = 'vtex.png'
 

--- a/react/__tests__/MediaList.test.tsx
+++ b/react/__tests__/MediaList.test.tsx
@@ -1,0 +1,778 @@
+import React from 'react'
+import type { ComponentType } from 'react'
+import { render } from '@vtex/test-tools/react'
+
+import MediaList from '../MediaList'
+import type {
+  ImageListSchemaElement,
+  MediaListSchemaElement,
+  VideoListSchemaElement,
+} from '../MediaTypes'
+
+let mockDeviceDetectorReturn = { isMobile: false }
+
+jest.mock('vtex.device-detector', () => ({
+  useDevice: jest.fn(() => mockDeviceDetectorReturn),
+}))
+
+const MediaListSiteEditor = MediaList as ComponentType<{
+  mediaList?: MediaListSchemaElement[]
+  height?: number
+}>
+
+describe('Using list-context.media-list block via site-editor', () => {
+  it('should render an youtube player correctly', () => {
+    const mediaList = [
+      {
+        mediaType: 'video',
+        video: 'https://www.youtube.com/watch?v=hT0OMD11b0A',
+      },
+    ] as VideoListSchemaElement[]
+
+    const { queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByTestId('html5-player')).not.toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).toBeInTheDocument()
+  })
+
+  it('should render a vimeo player correctly', () => {
+    const mediaList = [
+      {
+        mediaType: 'video',
+        video: 'https://vimeo.com/89404519',
+      },
+    ] as VideoListSchemaElement[]
+
+    const { queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByTestId('html5-player')).not.toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).not.toBeInTheDocument()
+  })
+
+  it('should render a HTML5 player correctly', () => {
+    const mediaList = [
+      {
+        mediaType: 'video',
+        video: 'http://vtex.com/vtex.mp4',
+      },
+    ] as VideoListSchemaElement[]
+
+    const { queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByTestId('html5-player')).toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).not.toBeInTheDocument()
+  })
+
+  it('should render a HTML5 player using "video" even if "src" is set', () => {
+    const video = 'http://vtex.com/vtex-video-url.mp4'
+    const src = 'http://vtex.com/vtex-src.mp4'
+
+    const mediaList = [
+      {
+        mediaType: 'video',
+        video,
+        src,
+      },
+    ] as Array<VideoListSchemaElement & { src: string }>
+
+    const { queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByTestId('html5-player')).toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).not.toBeInTheDocument()
+
+    // Checks if the <source> inside <video> has the correct src value
+    expect(queryByTestId('html5-player')?.firstElementChild).toHaveAttribute(
+      'src',
+      video
+    )
+  })
+
+  it('should render using mobileVideo when browsing through a mobile device', () => {
+    mockDeviceDetectorReturn = { isMobile: true }
+
+    const mediaList = [
+      {
+        mediaType: 'video',
+        video: 'https://www.youtube.com/watch?v=hT0OMD11b0A',
+        mobileVideo: 'http://vtex.com/vtex.mp4',
+      },
+    ] as VideoListSchemaElement[]
+
+    const { queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    // Cleaning vtex.device-detector mobile mock
+    mockDeviceDetectorReturn = { isMobile: false }
+
+    expect(queryByTestId('html5-player')).toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).not.toBeInTheDocument()
+  })
+
+  it('should render using video when browsing through a mobile device and mobileVideo is not set', () => {
+    mockDeviceDetectorReturn = { isMobile: true }
+
+    const mediaList = [
+      {
+        mediaType: 'video',
+        video: 'https://www.youtube.com/watch?v=hT0OMD11b0A',
+      },
+    ] as VideoListSchemaElement[]
+
+    const { queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    // Cleaning vtex.device-detector mobile mock
+    mockDeviceDetectorReturn = { isMobile: false }
+
+    expect(queryByTestId('html5-player')).not.toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).toBeInTheDocument()
+  })
+
+  it('should render using video when browsing through a desktop device, even if mobileVideo is set', () => {
+    const mediaList = [
+      {
+        mediaType: 'video',
+        video: 'https://www.youtube.com/watch?v=hT0OMD11b0A',
+        mobileVideo: 'http://vtex.com/vtex.mp4',
+      },
+    ] as VideoListSchemaElement[]
+
+    const { queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByTestId('html5-player')).not.toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).toBeInTheDocument()
+  })
+
+  it('should render a HTML5 player even if "video" is malformed', () => {
+    const mediaList = [
+      {
+        mediaType: 'video',
+        // File with no extension
+        video: 'vtex',
+      },
+    ] as VideoListSchemaElement[]
+
+    const { queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByTestId('html5-player')).toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).not.toBeInTheDocument()
+  })
+
+  it('should render HTML5, Youtube and Vimeo player', () => {
+    const mediaList = [
+      {
+        mediaType: 'video',
+        video: 'http://vtex.com/vtex.mp4',
+      },
+      {
+        mediaType: 'video',
+        video: 'https://www.youtube.com/watch?v=hT0OMD11b0A',
+      },
+      {
+        mediaType: 'video',
+        video: 'https://vimeo.com/89404519',
+      },
+    ] as VideoListSchemaElement[]
+
+    const { queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByTestId('html5-player')).toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).toBeInTheDocument()
+  })
+
+  it('should render an image correctly', () => {
+    const image = 'vtex.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        image,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+  })
+
+  it('should render an image with default maxHeight if height is not set', () => {
+    const DEFAULT_HEIGHT = 420
+    const image = 'vtex.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        image,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+    expect(queryByAltText(altText)).toHaveStyle(
+      `max-height: ${DEFAULT_HEIGHT}px`
+    )
+  })
+
+  it('should render an image with maxHeight if height is set', () => {
+    const image = 'vtex.png'
+    const altText = 'vtex-image'
+    const height = 300
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        image,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} height={height} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+    expect(queryByAltText(altText)).toHaveStyle(`max-height: ${height}px`)
+  })
+
+  it('should render an image with default width if it is not set', () => {
+    const DEFAULT_WIDTH = '100%'
+    const image = 'vtex.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        image,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+    expect(queryByAltText(altText)).toHaveStyle(`width: ${DEFAULT_WIDTH}`)
+  })
+
+  it('should render an image with width if it is set', () => {
+    const image = 'vtex.png'
+    const altText = 'vtex-image'
+    const width = '50%'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        width,
+        image,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+    expect(queryByAltText(altText)).toHaveStyle(`width: ${width}`)
+  })
+
+  it('should render an image using "image" even if "src" is set', () => {
+    const image = 'vtex-image.png'
+    const src = 'vtex-image-src.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        image,
+        src,
+      },
+    ] as Array<ImageListSchemaElement & { src: string }>
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+  })
+
+  it('should render using mobileImage when browsing through a mobile device', () => {
+    mockDeviceDetectorReturn = { isMobile: true }
+
+    const image = 'vtex-image.png'
+    const mobileImage = 'vtex-image-mobile.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        image,
+        mobileImage,
+      },
+    ] as Array<ImageListSchemaElement & { src: string }>
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    // Cleaning vtex.device-detector mobile mock
+    mockDeviceDetectorReturn = { isMobile: false }
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', mobileImage)
+  })
+
+  it('should render using image when browsing through a mobile device and mobileImage is not set', () => {
+    mockDeviceDetectorReturn = { isMobile: true }
+
+    const image = 'vtex-image.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        image,
+      },
+    ] as Array<ImageListSchemaElement & { src: string }>
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    // Cleaning vtex.device-detector mobile mock
+    mockDeviceDetectorReturn = { isMobile: false }
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+  })
+
+  it('should render using image when browsing through a desktop device, even if mobileImage is set', () => {
+    const image = 'vtex-image.png'
+    const mobileImage = 'vtex-image-mobile.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        image,
+        mobileImage,
+      },
+    ] as Array<ImageListSchemaElement & { src: string }>
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+  })
+
+  it('should render a list of images correctly', () => {
+    const image1 = 'vtex-1.png'
+    const image2 = 'vtex-2.png'
+    const image3 = 'vtex-3.png'
+    const altText1 = 'vtex-image-1'
+    const altText2 = 'vtex-image-2'
+    const altText3 = 'vtex-image-3'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText1,
+        image: image1,
+      },
+      {
+        mediaType: 'image',
+        description: altText2,
+        image: image2,
+      },
+      {
+        mediaType: 'image',
+        description: altText3,
+        image: image3,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText1)).toBeInTheDocument()
+    expect(queryByAltText(altText2)).toBeInTheDocument()
+    expect(queryByAltText(altText3)).toBeInTheDocument()
+    expect(queryByAltText(altText1)).toHaveAttribute('src', image1)
+    expect(queryByAltText(altText2)).toHaveAttribute('src', image2)
+    expect(queryByAltText(altText3)).toHaveAttribute('src', image3)
+  })
+
+  it('should render an image even if "image" is malformed', () => {
+    // File with no extension
+    const image = 'vtex'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText,
+        image,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+  })
+
+  it('should render a list of images and videos correctly', () => {
+    const image1 = 'vtex-1.png'
+    const image2 = 'vtex-2.png'
+    const altText1 = 'vtex-image-1'
+    const altText2 = 'vtex-image-2'
+
+    const mediaList = [
+      {
+        mediaType: 'image',
+        description: altText1,
+        image: image1,
+      },
+      {
+        mediaType: 'video',
+        video: 'http://vtex.com/vtex.mp4',
+      },
+      {
+        mediaType: 'image',
+        description: altText2,
+        image: image2,
+      },
+      {
+        mediaType: 'video',
+        video: 'https://www.youtube.com/watch?v=hT0OMD11b0A',
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText, queryByTestId } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText1)).toBeInTheDocument()
+    expect(queryByAltText(altText2)).toBeInTheDocument()
+    expect(queryByAltText(altText1)).toHaveAttribute('src', image1)
+    expect(queryByAltText(altText2)).toHaveAttribute('src', image2)
+    expect(queryByTestId('html5-player')).toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).toBeInTheDocument()
+  })
+})
+
+describe('Migration from list-context.image-list to list-context.media-list', () => {
+  // The cases below are only possible in case of migration from
+  // list-context.image-list to list.context.media-list
+  it('should render an image correctly', () => {
+    const image = 'vtex.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        description: altText,
+        image,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+  })
+
+  it('should render an image using "image" even if "src" is set', () => {
+    const image = 'vtex-image.png'
+    const src = 'vtex-src.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        description: altText,
+        image,
+        src,
+      },
+    ] as Array<ImageListSchemaElement & { src: string }>
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+  })
+
+  it('should render a list of images correctly', () => {
+    const image1 = 'vtex-1.png'
+    const image2 = 'vtex-2.png'
+    const image3 = 'vtex-3.png'
+    const altText1 = 'vtex-image-1'
+    const altText2 = 'vtex-image-2'
+    const altText3 = 'vtex-image-3'
+
+    const mediaList = [
+      {
+        description: altText1,
+        image: image1,
+      },
+      {
+        description: altText2,
+        image: image2,
+      },
+      {
+        description: altText3,
+        image: image3,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText1)).toBeInTheDocument()
+    expect(queryByAltText(altText2)).toBeInTheDocument()
+    expect(queryByAltText(altText3)).toBeInTheDocument()
+    expect(queryByAltText(altText1)).toHaveAttribute('src', image1)
+    expect(queryByAltText(altText2)).toHaveAttribute('src', image2)
+    expect(queryByAltText(altText3)).toHaveAttribute('src', image3)
+  })
+
+  it('should render an image even if "image" is malformed', () => {
+    // File with no extension
+    const image = 'vtex'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        description: altText,
+        image,
+      },
+    ] as ImageListSchemaElement[]
+
+    const { queryByAltText } = render(
+      <MediaListSiteEditor mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', image)
+  })
+})
+
+describe('Using list-context.media-list as a React Component', () => {
+  it('should render an youtube player correctly', () => {
+    const mediaList = [
+      {
+        src: 'https://www.youtube.com/watch?v=hT0OMD11b0A',
+      },
+    ]
+
+    const { queryByTestId } = render(<MediaList mediaList={mediaList} />)
+
+    expect(queryByTestId('html5-player')).not.toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).toBeInTheDocument()
+  })
+
+  it('should render a vimeo player correctly', () => {
+    const mediaList = [
+      {
+        src: 'https://vimeo.com/89404519',
+      },
+    ]
+
+    const { queryByTestId } = render(<MediaList mediaList={mediaList} />)
+
+    expect(queryByTestId('html5-player')).not.toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).not.toBeInTheDocument()
+  })
+
+  it('should render a HTML5 player correctly', () => {
+    const mediaList = [
+      {
+        src: 'http://vtex.com/vtex.mp4',
+      },
+    ]
+
+    const { queryByTestId } = render(<MediaList mediaList={mediaList} />)
+
+    expect(queryByTestId('html5-player')).toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).not.toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).not.toBeInTheDocument()
+  })
+
+  it('should render HTML5, Youtube and Vimeo player', () => {
+    const mediaList = [
+      {
+        src: 'http://vtex.com/vtex.mp4',
+      },
+      {
+        src: 'https://www.youtube.com/watch?v=hT0OMD11b0A',
+      },
+      {
+        src: 'https://vimeo.com/89404519',
+      },
+    ]
+
+    const { queryByTestId } = render(<MediaList mediaList={mediaList} />)
+
+    expect(queryByTestId('html5-player')).toBeInTheDocument()
+    expect(queryByTestId('vimeo-player')).toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).toBeInTheDocument()
+  })
+
+  it('should render an image correctly', () => {
+    const src = 'vtex.png'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        alt: altText,
+        src,
+      },
+    ]
+
+    const { queryByAltText } = render(<MediaList mediaList={mediaList} />)
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', src)
+  })
+
+  it('should render a list of images correctly', () => {
+    const src1 = 'vtex-1.png'
+    const src2 = 'vtex-2.png'
+    const src3 = 'vtex-3.png'
+    const altText1 = 'vtex-image-1'
+    const altText2 = 'vtex-image-2'
+    const altText3 = 'vtex-image-3'
+
+    const mediaList = [
+      {
+        alt: altText1,
+        src: src1,
+      },
+      {
+        alt: altText2,
+        src: src2,
+      },
+      {
+        alt: altText3,
+        src: src3,
+      },
+    ]
+
+    const { queryByAltText } = render(<MediaList mediaList={mediaList} />)
+
+    expect(queryByAltText(altText1)).toBeInTheDocument()
+    expect(queryByAltText(altText2)).toBeInTheDocument()
+    expect(queryByAltText(altText3)).toBeInTheDocument()
+    expect(queryByAltText(altText1)).toHaveAttribute('src', src1)
+    expect(queryByAltText(altText2)).toHaveAttribute('src', src2)
+    expect(queryByAltText(altText3)).toHaveAttribute('src', src3)
+  })
+
+  it('should render an image even if "src" is malformed', () => {
+    // File with no extension
+    const src = 'vtex'
+    const altText = 'vtex-image'
+
+    const mediaList = [
+      {
+        alt: altText,
+        src,
+      },
+    ]
+
+    const { queryByAltText } = render(<MediaList mediaList={mediaList} />)
+
+    expect(queryByAltText(altText)).toBeInTheDocument()
+    expect(queryByAltText(altText)).toHaveAttribute('src', src)
+  })
+
+  it('should render a list of images and videos correctly', () => {
+    const imageSrc1 = 'vtex-1.png'
+    const imageSrc2 = 'vtex-2.png'
+    const altText1 = 'vtex-image-1'
+    const altText2 = 'vtex-image-2'
+
+    const mediaList = [
+      {
+        alt: altText1,
+        src: imageSrc1,
+      },
+      {
+        src: 'http://vtex.com/vtex.mp4',
+      },
+      {
+        alt: altText2,
+        src: imageSrc2,
+      },
+      {
+        src: 'https://www.youtube.com/watch?v=hT0OMD11b0A',
+      },
+    ]
+
+    const { queryByAltText, queryByTestId } = render(
+      <MediaList mediaList={mediaList} />
+    )
+
+    expect(queryByAltText(altText1)).toBeInTheDocument()
+    expect(queryByAltText(altText2)).toBeInTheDocument()
+    expect(queryByAltText(altText1)).toHaveAttribute('src', imageSrc1)
+    expect(queryByAltText(altText2)).toHaveAttribute('src', imageSrc2)
+    expect(queryByTestId('html5-player')).toBeInTheDocument()
+    expect(queryByTestId('youtube-player')).toBeInTheDocument()
+  })
+})

--- a/react/modules/mediaAsList.tsx
+++ b/react/modules/mediaAsList.tsx
@@ -5,14 +5,13 @@ import type {
   ImageModeProps,
   VideoModeProps,
   ImageListSchemaElement,
-  MediaArray,
   VideoListSchemaElement,
   MediaListSchemaElement,
   MediaProps,
 } from '../MediaTypes'
 
 export const getMediaAsJSXList = (
-  mediaList: MediaArray,
+  mediaList: MediaProps[],
   isMobile: boolean,
   maxHeight?: string | number
 ) => {

--- a/react/modules/mediaAsList.tsx
+++ b/react/modules/mediaAsList.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+
+import Media from '../Media'
+import type {
+  ImageModeProps,
+  VideoModeProps,
+  ImageListSchemaElement,
+  MediaArray,
+  VideoListSchemaElement,
+  MediaListSchemaElement,
+  MediaProps,
+} from '../MediaTypes'
+
+export const getMediaAsJSXList = (
+  mediaList: MediaArray,
+  isMobile: boolean,
+  maxHeight?: string | number
+) => {
+  return mediaList.map((props: MediaProps | MediaListSchemaElement, idx) => {
+    const { mediaType } = props as MediaProps
+
+    const {
+      image,
+      mobileImage,
+      // This is here to mantain compatibility with list-context.image-list
+      description,
+      width = '100%',
+    } = props as ImageListSchemaElement
+
+    // If it's being used as a block and it's set to be 'image', 'imageOrVideo' or undefined
+    if (mediaType !== 'video' && (image || mobileImage)) {
+      return (
+        <Media
+          key={idx}
+          {...(props as ImageModeProps)}
+          mediaType="image"
+          src={isMobile && mobileImage ? mobileImage : image}
+          // These are here to mantain compatibility with list-context.image-list
+          alt={description}
+          maxHeight={maxHeight ?? 420}
+          width={width}
+        />
+      )
+    }
+
+    const { video, mobileVideo } = props as VideoListSchemaElement
+
+    // If it's being used as a block and it's set to be 'video', 'imageOrVideo' or undefined
+    if (mediaType !== 'image' && (video || mobileVideo)) {
+      return (
+        <Media
+          key={idx}
+          {...(props as VideoModeProps)}
+          mediaType="video"
+          src={isMobile && mobileVideo ? mobileVideo : video}
+        />
+      )
+    }
+
+    // If it's being used as a React Component
+    // mediaType can be either 'image', 'video', 'imageOrVideo' or undefined
+    return <Media key={idx} {...(props as MediaProps)} />
+  })
+}

--- a/react/package.json
+++ b/react/package.json
@@ -23,8 +23,10 @@
     "graphql": "^14.6.0",
     "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime",
-    "vtex.store-image": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.8.0/public/@types/vtex.store-image",
-    "vtex.store-video": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.2.0/public/@types/vtex.store-video"
+    "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
+    "vtex.list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.2.0/public/@types/vtex.list-context",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime",
+    "vtex.store-image": "https://icaromedia5--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.store-image@0.8.0+build1611865299/public/@types/vtex.store-image",
+    "vtex.store-video": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.3.0/public/@types/vtex.store-video"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,7 @@
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
     "vtex.list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.2.0/public/@types/vtex.list-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime",
-    "vtex.store-image": "https://icaromedia5--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.store-image@0.8.0+build1611865299/public/@types/vtex.store-image",
+    "vtex.store-image": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.9.0/public/@types/vtex.store-image",
     "vtex.store-video": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.3.0/public/@types/vtex.store-video"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4962,9 +4962,9 @@ verror@1.10.0:
   version "8.126.10"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime#1eb37d8ef0fcaef17060306f6d5dff6d9e404d39"
 
-"vtex.store-image@https://icaromedia5--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.store-image@0.8.0+build1611865299/public/@types/vtex.store-image":
-  version "0.8.0"
-  resolved "https://icaromedia5--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.store-image@0.8.0+build1611865299/public/@types/vtex.store-image#0c0b093fa2a5eca187918c842eaf4d384a1c8a0d"
+"vtex.store-image@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.9.0/public/@types/vtex.store-image":
+  version "0.9.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.9.0/public/@types/vtex.store-image#56a0d07cd0fd2ee7f5413fbced139ef8a04664d0"
 
 "vtex.store-video@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.3.0/public/@types/vtex.store-video":
   version "1.3.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4950,17 +4950,25 @@ verror@1.10.0:
   version "1.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles#336b23ef3a9bcb2b809529ba736783acd405d081"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime":
-  version "8.126.7"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime#bf00fb2ef41c5158c566c12dc6dd9dd0d5c2a9e9"
+"vtex.device-detector@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector":
+  version "0.2.6"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector#3219242fa5c2f14023d33c3549c2d8de93c76d1f"
 
-"vtex.store-image@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.8.0/public/@types/vtex.store-image":
+"vtex.list-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.2.0/public/@types/vtex.list-context":
+  version "0.2.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.2.0/public/@types/vtex.list-context#935b748d394851ced7f3b06bbedf59f4ee3ca8a6"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime":
+  version "8.126.10"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime#1eb37d8ef0fcaef17060306f6d5dff6d9e404d39"
+
+"vtex.store-image@https://icaromedia5--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.store-image@0.8.0+build1611865299/public/@types/vtex.store-image":
   version "0.8.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.8.0/public/@types/vtex.store-image#de3ceed5553e2253d362321b5743894e1483c925"
+  resolved "https://icaromedia5--storecomponents.myvtex.com/_v/private/typings/linked/v1/vtex.store-image@0.8.0+build1611865299/public/@types/vtex.store-image#0c0b093fa2a5eca187918c842eaf4d384a1c8a0d"
 
-"vtex.store-video@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.2.0/public/@types/vtex.store-video":
-  version "1.2.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.2.0/public/@types/vtex.store-video#c947a378dec79fe89136e7530e7e8d58c730de65"
+"vtex.store-video@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.3.0/public/@types/vtex.store-video":
+  version "1.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.3.0/public/@types/vtex.store-video#2b6508047aec46207e1499463d35216ddb6ed944"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,19 +1,21 @@
 {
   "definitions": {
+    "videoDependency": {},
     "Media": {
       "title": "admin/editor.media.title",
       "description": "admin/editor.media.description",
       "properties": {
         "mediaType": {
-          "title": "admin/editor.media.mediaType.title",
+          "title": "admin/editor.mediaType.title",
           "type": "string",
           "enum": ["image", "video"],
           "enumNames": [
-            "admin/editor.media.mediaType.image",
-            "admin/editor.media.mediaType.video"
+            "admin/editor.mediaType.image",
+            "admin/editor.mediaType.video"
           ]
         }
       },
+      "required": ["mediaType"],
       "dependencies": {
         "mediaType": {
           "oneOf": [
@@ -22,21 +24,7 @@
                 "mediaType": {
                   "enum": ["image"]
                 },
-                "src": {
-                  "$ref": "app:vtex.store-image#/definitions/Image/properties/src"
-                },
-                "link": {
-                  "$ref": "app:vtex.store-image#/definitions/Image/properties/link"
-                },
-                "alt": {
-                  "$ref": "app:vtex.store-image#/definitions/Image/properties/alt"
-                },
-                "title": {
-                  "$ref": "app:vtex.store-image#/definitions/Image/properties/title"
-                },
-                "analyticsProperties": {
-                  "$ref": "app:vtex.store-image#/definitions/Image/properties/analyticsProperties"
-                }
+                "$ref": "app:vtex.store-image#/definitions/Image/properties"
               },
               "dependencies": {
                 "$ref": "app:vtex.store-image#/definitions/Image/dependencies"
@@ -77,6 +65,78 @@
               }
             }
           ]
+        }
+      }
+    },
+    "MediaList": {
+      "title": "admin/editor.mediaList.title",
+      "description": "admin/editor.mediaList.description",
+      "properties": {
+        "mediaList": {
+          "title": "admin/editor.mediaList.title",
+          "type": "array",
+          "items": {
+            "title": "admin/editor.mediaList.title",
+            "properties": {
+              "$ref": "app:vtex.store-media#/definitions/Media/properties"
+            },
+            "required": ["mediaType"],
+            "dependencies": {
+              "mediaType": {
+                "oneOf": [
+                  {
+                    "properties": {
+                      "mediaType": {
+                        "enum": ["image"]
+                      },
+                      "$ref": "app:vtex.store-image#/definitions/Images/items/properties"
+                    },
+                    "dependencies": {
+                      "$ref": "app:vtex.store-image#/definitions/Images/items/dependencies"
+                    }
+                  },
+                  {
+                    "properties": {
+                      "mediaType": {
+                        "enum": ["video"]
+                      },
+                      "video": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/src"
+                      },
+                      "mobileVideo": {
+                        "title": "admin/editor.mediaList.mobileVideo.title",
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/src"
+                      },
+                      "name": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/name"
+                      },
+                      "description": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/description"
+                      },
+                      "width": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/width"
+                      },
+                      "height": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/height"
+                      },
+                      "autoPlay": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/autoPlay"
+                      },
+                      "loop": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/loop"
+                      },
+                      "poster": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/poster"
+                      },
+                      "uploadDate": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/uploadDate"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
         }
       }
     }

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,6 +1,5 @@
 {
   "definitions": {
-    "videoDependency": {},
     "Media": {
       "title": "admin/editor.media.title",
       "description": "admin/editor.media.description",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -4,5 +4,13 @@
     "content": {
       "$ref": "app:vtex.store-media#/definitions/Media"
     }
+  },
+  "list-context.media-list": {
+    "component": "MediaList",
+    "composition": "children",
+    "allowed": "*",
+    "content": {
+      "$ref": "app:vtex.store-media#/definitions/MediaList"
+    }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -8,7 +8,6 @@
   "list-context.media-list": {
     "component": "MediaList",
     "composition": "children",
-    "allowed": "*",
     "content": {
       "$ref": "app:vtex.store-media#/definitions/MediaList"
     }


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the `list-context.media-list` block that's fully compatible with `list-context.image-list` props and supports image and video assets. It also improves CSS Handles imports from the `store-image` and `store-video` apps, types and tests.

#### How to test it?
Play with the carousel on this workspace:

[Workspace](https://icaromedia5--storecomponents.myvtex.com/)
[Test it on the site editor](https://icaromedia5--storecomponents.myvtex.com/admin/cms/site-editor)

#### Screenshots or example usage:

<img src="https://user-images.githubusercontent.com/8127610/106201668-8d174300-6197-11eb-9e6a-47cc8fdb2e6f.gif" height="400px" />

#### Related to / Depends on

Depends on [store-image#32](https://github.com/vtex-apps/store-image/pull/32)
Depends on [store-video#6](https://github.com/vtex-apps/store-video/pull/6)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/E7ypU2qtdDyS3FN1TN/giphy-downsized-large.gif)
