### PR TITLE
Adding playsInline video prop to contentSchemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `playsInline` prop to the video content schemas
 
 ## [0.2.0] - 2021-02-08
 ### Added

--- a/react/package.json
+++ b/react/package.json
@@ -27,6 +27,6 @@
     "vtex.list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.2.0/public/@types/vtex.list-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
     "vtex.store-image": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.10.0/public/@types/vtex.store-image",
-    "vtex.store-video": "https://icarovtexvideo--muji.myvtex.com/_v/private/typings/linked/v1/vtex.store-video@1.3.0+build1614972004/public/@types/vtex.store-video"
+    "vtex.store-video": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.4.0/public/@types/vtex.store-video"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -25,8 +25,8 @@
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@1.0.0/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
     "vtex.list-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.2.0/public/@types/vtex.list-context",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime",
-    "vtex.store-image": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.9.0/public/@types/vtex.store-image",
-    "vtex.store-video": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.3.0/public/@types/vtex.store-video"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
+    "vtex.store-image": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.10.0/public/@types/vtex.store-image",
+    "vtex.store-video": "https://icarovtexvideo--muji.myvtex.com/_v/private/typings/linked/v1/vtex.store-video@1.3.0+build1614972004/public/@types/vtex.store-video"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4966,9 +4966,9 @@ verror@1.10.0:
   version "0.10.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.10.0/public/@types/vtex.store-image#99963acaed144f87635ce6ed8b6a99230607e8f4"
 
-"vtex.store-video@https://icarovtexvideo--muji.myvtex.com/_v/private/typings/linked/v1/vtex.store-video@1.3.0+build1614972004/public/@types/vtex.store-video":
-  version "1.3.0"
-  resolved "https://icarovtexvideo--muji.myvtex.com/_v/private/typings/linked/v1/vtex.store-video@1.3.0+build1614972004/public/@types/vtex.store-video#bb744b3af9581e7bbfad7741c3048f7e24159396"
+"vtex.store-video@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.4.0/public/@types/vtex.store-video":
+  version "1.4.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.4.0/public/@types/vtex.store-video#65e43f18ea9bfe382b5f0553a2e716e490900e82"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -4958,17 +4958,17 @@ verror@1.10.0:
   version "0.2.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.list-context@0.2.0/public/@types/vtex.list-context#935b748d394851ced7f3b06bbedf59f4ee3ca8a6"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime":
-  version "8.126.10"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime#1eb37d8ef0fcaef17060306f6d5dff6d9e404d39"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
+  version "8.126.11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
 
-"vtex.store-image@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.9.0/public/@types/vtex.store-image":
-  version "0.9.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.9.0/public/@types/vtex.store-image#56a0d07cd0fd2ee7f5413fbced139ef8a04664d0"
+"vtex.store-image@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.10.0/public/@types/vtex.store-image":
+  version "0.10.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-image@0.10.0/public/@types/vtex.store-image#99963acaed144f87635ce6ed8b6a99230607e8f4"
 
-"vtex.store-video@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.3.0/public/@types/vtex.store-video":
+"vtex.store-video@https://icarovtexvideo--muji.myvtex.com/_v/private/typings/linked/v1/vtex.store-video@1.3.0+build1614972004/public/@types/vtex.store-video":
   version "1.3.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-video@1.3.0/public/@types/vtex.store-video#2b6508047aec46207e1499463d35216ddb6ed944"
+  resolved "https://icarovtexvideo--muji.myvtex.com/_v/private/typings/linked/v1/vtex.store-video@1.3.0+build1614972004/public/@types/vtex.store-video#bb744b3af9581e7bbfad7741c3048f7e24159396"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -55,6 +55,9 @@
                 "loop": {
                   "$ref": "app:vtex.store-video#/definitions/Video/properties/loop"
                 },
+                "playsInline": {
+                  "$ref": "app:vtex.store-video#/definitions/Video/properties/playsInline"
+                },
                 "poster": {
                   "$ref": "app:vtex.store-video#/definitions/Video/properties/poster"
                 },
@@ -123,6 +126,9 @@
                       },
                       "loop": {
                         "$ref": "app:vtex.store-video#/definitions/Video/properties/loop"
+                      },
+                      "playsInline": {
+                        "$ref": "app:vtex.store-video#/definitions/Video/properties/playsInline"
                       },
                       "poster": {
                         "$ref": "app:vtex.store-video#/definitions/Video/properties/poster"


### PR DESCRIPTION
#### What problem is this solving?

This PR adds support for `store-video`'s new prop `playsInline` via the site editor.

#### How to test it?

Go to the site editor on the workspace below and on the Story 1 - Toggle media, there's a video. Since it already has autoPlay enabled, it has the `displaysinline` property on the dom, no matter the value on the `playsInline` toggle. Try disabling autoplay and enabling the playsInline toggle and inspect the element to see that it still includes the `playsinline` property.

[Workspace](https://icarovtexvideo--muji.myvtex.com/admin/cms/site-editor/how-to-muji-face-soap?__siteEditor&__bindingAddress=www.mujionline.eu/uk)

#### Screenshots or example usage:

<img width="261" alt="Screen Shot 2021-03-05 at 16 56 39" src="https://user-images.githubusercontent.com/8127610/110166915-c3b62e00-7dd3-11eb-99c6-0a8c0198ef57.png">

#### Related to / Depends on

Depends on [store-video#7](https://github.com/vtex-apps/store-video/pull/7)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/3ornjPby6F2oHVkJQA/giphy.gif)
